### PR TITLE
Fixed categories baking

### DIFF
--- a/_piecrust/src/PieCrust/Baker/PieCrustBaker.php
+++ b/_piecrust/src/PieCrust/Baker/PieCrustBaker.php
@@ -489,13 +489,13 @@ class PieCrustBaker
             if ($blogKey != PieCrust::DEFAULT_BLOG_KEY)
                 $prefix = $blogKey . DIRECTORY_SEPARATOR;
                 
-            $categoryPagePath = $this->pieCrust->getPagesDir() . $blogKey . PieCrust::CATEGORY_PAGE_NAME . '.html';
+            $categoryPagePath = $this->pieCrust->getPagesDir() . $prefix . PieCrust::CATEGORY_PAGE_NAME . '.html';
             if (!is_file($categoryPagePath)) return;
             
             foreach ($this->bakeRecord->getCategoriesToBake($blogKey) as $category)
             {
                 $start = microtime(true);
-                $postInfos = $this->getPostsInCategory($blogKey, $category);
+                $postInfos = $this->bakeRecord->getPostsInCategory($blogKey, $category);
                 $uri = UriBuilder::buildCategoryUri($this->pieCrust->getConfigValue($blogKey, 'category_url'), $category);
                 $page = PageRepository::getOrCreatePage(
                     $this->pieCrust, 


### PR DESCRIPTION
There were two typos that prevented categories being baked - first the wrong prefix was used for constructing path to template file and secondly getPostsInCategory was called on PieCrustBaker instead of BakeRecord. Works for me with this fix...
