### PR TITLE
Recapturing now works

### DIFF
--- a/_piecrust/src/PieCrust/IO/FileSystem.php
+++ b/_piecrust/src/PieCrust/IO/FileSystem.php
@@ -76,7 +76,6 @@ abstract class FileSystem
         );
         if ($needsRecapture)
         {
-            die("RECAPTURE");
             // Not all path components were specified in the URL (e.g. because the
             // post URL format doesn't capture all of them).
             // We need to find a physical file that matches everything we have,
@@ -90,8 +89,10 @@ abstract class FileSystem
             $pathComponentsRegex = preg_quote($this->getPathFormat(), '/');
             $pathComponentsRegex = str_replace(
                 array('%year%', '%month%', '%day%', '%slug%'),
-                array('(\d{4})', '(\d{2})', '(\d{2})', '(\d{2})')
+                array('(\d{4})', '(\d{2})', '(\d{2})', '(.+)'),
+                $pathComponentsRegex
             );
+            $pathComponentsRegex = '/' . $pathComponentsRegex . '/';
             $pathComponentsMatches = array();
             if (preg_match($pathComponentsRegex, str_replace('\\', '/', $possiblePaths[0]), $pathComponentsMatches) !== 1)
                 throw new PieCrustException("Can't extract path components from path: " . $possiblePaths[0]);


### PR DESCRIPTION
Me again :) Finally updated to latest version and it broke my site as it didn't handle recapturing when using partial `post_url`. There were several issues with the code:
- First of all, `die()` prevented recapturing, so removed it.
- Then `str_replace` was missing third parameter (source string) when creating matching regex.
- Regex was using invalid matcher for slug (`\d{2}` only matches two digits, but slug is arbitrary string).
- Finally `preg_match` requires embedding regex within Perl style `/` chars.

I tested with my setup and works just fine, take a look. Didn't check unit tests as you proposed last time, I'm barely struggling with PHP and Apache, it took me a couple of hours to figure out this patch, so it seems too involving for my current time... :)

A couple more things to do, then I can make my PieCrust site live and finally ditch WordPress... Thanks!
