### PR TITLE
use new static() instead of new Page() in Page

### DIFF
--- a/_piecrust/src/PieCrust/Page/Page.php
+++ b/_piecrust/src/PieCrust/Page/Page.php
@@ -170,9 +170,9 @@ class Page implements IPage
     /**
      * Gets all the page's formatted content segments.
      */
-    public function getContentSegments()
+    public function getContentSegments($ensureFormatted = true)
     {
-        $this->ensureContentsLoaded();
+        if($ensureFormatted) $this->ensureContentsLoaded();
         return $this->contents;
     }
     


### PR DESCRIPTION
make Page's static methods return new static() instead of new Page() so that classes extending Page can work without copy-and-pasting the static methods
