### PR TITLE
$server['HTTP_ACCEPT_ENCODING'] doesn't always exist

### DIFF
--- a/src/PieCrust/Runner/PieCrustRunner.php
+++ b/src/PieCrust/Runner/PieCrustRunner.php
@@ -132,6 +132,7 @@ class PieCrustRunner
     
         // Output with or without GZip compression.
         $gzipEnabled = (($this->pieCrust->getConfig()->getValueUnchecked('site/enable_gzip') === true) and
+                        (array_key_exists('HTTP_ACCEPT_ENCODING', $server)) and
                         (strpos($server['HTTP_ACCEPT_ENCODING'], 'gzip') !== false));
         if ($gzipEnabled)
         {


### PR DESCRIPTION
We found on one of our servers that HTTP_ACCEPT_ENCODING wasn't always set for all clients (worked for real browsers, failed for curl/wget), which was causing those clients to see the PieCrust error page instead of content. This patch fixed it up.
