### PR TITLE
Fix for the Read-more link in RSS/Atom feeds

### DIFF
--- a/res/prepare/atom.html
+++ b/res/prepare/atom.html
@@ -35,7 +35,7 @@ content_type: xml
         <updated>{{post.timestamp|atomdate}}</updated>
         <content type="html">{{post.content}}
 		{% if post.has_more and page.read_more_text %}
-		{{ "<a href=\"" ~ post.url ~ "\">" ~ page.read_more_text ~ "</a>"|escape }}
+		{{ ("<a href=\"" ~ post.url ~ "\">" ~ page.read_more_text ~ "</a>")|escape }}
 		{% endif %}
 		</content>
 		{% if author %}

--- a/res/prepare/rss.html
+++ b/res/prepare/rss.html
@@ -51,7 +51,7 @@ content_type: xml
             <guid>{{post.url}}</guid>
             <description>{{post.content}}
             {% if post.has_more and page.read_more_text %}
-            {{ "<a href=\"" ~ post.url ~ "\">" ~ page.read_more_text ~ "</a>"|escape }}
+            {{ ("<a href=\"" ~ post.url ~ "\">" ~ page.read_more_text ~ "</a>")|escape }}
             {% endif %}
             </description>
         </item>


### PR DESCRIPTION
There was a bug in the RSS/Atom feeds:

![33bcY5d](https://f.cloud.github.com/assets/3730074/240079/a85da07e-88f0-11e2-89a4-091b71b7d7a7.jpg)

So now it's gone!
