### PR TITLE
Fix for post filtering when there're multiple calls with filtering

### DIFF
--- a/src/PieCrust/Page/Iteration/PageIterator.php
+++ b/src/PieCrust/Page/Iteration/PageIterator.php
@@ -34,6 +34,8 @@ class PageIterator extends BaseIterator
     protected $nextPost;
     protected $hasMorePosts;
     
+    protected $dataSource;
+    
     public function __construct(IPieCrust $pieCrust, $blogKey, array $dataSource)
     {
         parent::__construct();
@@ -41,6 +43,7 @@ class PageIterator extends BaseIterator
         $this->pieCrust = $pieCrust;
         $this->blogKey = $blogKey;
         
+        $this->dataSource = $dataSource;
         $this->iterator = new WrapperIterator($dataSource);
         $this->gotSorter = false;
         $this->isLocked = false;
@@ -335,6 +338,13 @@ class PageIterator extends BaseIterator
             $postsData[] = new PaginationData($post);
         }
         return $postsData;
+    }
+    
+    public function rewind() {
+    	parent::rewind();
+    	$this->iterator = new WrapperIterator($this->dataSource);
+    	$this->gotSorter = false;
+    	$this->ensureSorter();
     }
     // }}}
 }


### PR DESCRIPTION
We are migrating tupilabs.com from Wordpress to PieCrust! :D Thanks for such a great tool.

One problem that we found during the migration was that we displayed three posts from three categories in the home page: news, blog and ideas.

We had three blocks, using `for post in blog.posts.in_category('blog').limit(3)`, However, only the first set of posts were displayed. It happened because the original WrapperIterator was replaced by a ConfigFilterIterator, and in the next call the ConfigFilterIterator couldn't be used correctly (we needed the original WrapperIterator).

After patching the PageIterator we fixed this issue. The patched PageIterator in this pull requests works for us, but please feel free to massage the code or make any necessary modifications.

Thanks once again!
Bruno
