### PR TITLE
Fix to database encoding for WordPress import

### DIFF
--- a/src/PieCrust/Interop/Importers/WordpressImporter.php
+++ b/src/PieCrust/Interop/Importers/WordpressImporter.php
@@ -131,7 +131,17 @@ EOD;
         $this->tablePrefix = $tablePrefix;
 
         // Use UTF8 encoding.
-        mysql_set_charset('utf8');
+        $query = mysql_query('SHOW VARIABLES LIKE  "character_set_database"');
+        if ($row = mysql_fetch_assoc($query))
+        {
+            $db_character_set = $row['Value'];
+
+            mysql_set_charset($db_character_set);
+        }
+		else
+		{
+			mysql_set_charset('utf8');
+		}
 
         // Gather the authors' names.
         $this->authors = array();


### PR DESCRIPTION
This fixes [Unicode import from wordpress](https://github.com/ludovicchabant/PieCrust/issues/92). I'm not entirely sure you even need to send a `mysql_set_charset` though, since my change basically just sends what it's alreayd defaulted to.
