### PR TITLE
Added support for passing PHPMarkdown parser configuration parameters

### DIFF
--- a/src/PieCrust/Formatters/MarkdownFormatter.php
+++ b/src/PieCrust/Formatters/MarkdownFormatter.php
@@ -10,6 +10,7 @@ class MarkdownFormatter implements IFormatter
     protected $pieCrust;
     protected $libDir;
     protected $parser;
+    protected $markdown_config;
     
     public function initialize(IPieCrust $pieCrust)
     {
@@ -19,6 +20,10 @@ class MarkdownFormatter implements IFormatter
         if ($pieCrust->getConfig()->getValue('markdown/use_markdown_extra') === true)
         {
             $this->libDir = 'markdown-extra';
+        }
+        if ($markdown_config = $pieCrust->getConfig()->getValue('markdown/config'))
+        {
+            $this->markdown_config = $markdown_config;
         }
     }
     
@@ -47,6 +52,13 @@ class MarkdownFormatter implements IFormatter
         }
 
         $this->parser->fn_id_prefix = '';
+        if (isset($this->markdown_config))
+        {
+            foreach ($this->markdown_config as $param=>$value)
+            {
+                $this->parser->$param = $value;
+            }
+        }
         $executionContext = $this->pieCrust->getEnvironment()->getExecutionContext();
         if ($executionContext != null)
         {


### PR DESCRIPTION
Patch allows the inclusion of parser parameters in the `_content/config.yml` file inside the `markdown\config` section, for example:

``` yaml
markdown:
    use_markdown_extra: true
    config:
        code_attr_on_pre: true
        fn_link_class: 'myfootnote'
```

The configuration above will set class parameters for fenced codes in the `<pre>` tag, instead of putting that in `<code>`, and will also set `myfootnote` as the class used for the footnote links.
