### PR TITLE
Fix links to website

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -2,7 +2,7 @@
 [![build status](https://secure.travis-ci.org/ludovicchabant/PieCrust.png?branch=master)](http://travis-ci.org/ludovicchabant/PieCrust)
 
 *__ATTENTION__: PieCrust 1.x is deprecated. Please update to PieCrust 2.x. See
-[the official website](http://bolt80.com/piecrust) for details.*
+[the official website](https://bolt80.com/piecrust) for details.*
 
 
 PieCrust is a static website generator and lightweight CMS that's all managed
@@ -10,7 +10,7 @@ with text files. No complex setup, databases, or administrative panels.
 Simple, beautiful, and yummy.
 
 For more information, along with the complete documentation, visit [the
-official website](http://bolt80.com/piecrust/).
+official website](https://bolt80.com/piecrust/).
 
 
 Quickstart


### PR DESCRIPTION
The HTTP link to `http://bolt80.com/piecrust/` are rewritten to `https://bolt80.compiecrust/`. Seems like a broken rewrite rule. Linking directly to the HTTPS site works.
